### PR TITLE
perl version correction

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -6,7 +6,7 @@ author:
   - Jan Dubois <jand@activestate.com>
 license: perl
 requires: 
-  perl: 5.6
+  perl: 5.006
 resources:
   license: http://dev.perl.org/licenses/
   homepage: http://code.google.com/p/libwin32/


### PR DESCRIPTION
See http://grokbase.com/t/perl/perl5-porters/139jzvdp2q/perl-119879-cannot-install-module-requiring-perl-5-6-via-cpan
