### PR TITLE
Replace stricmp with strcasecmp

### DIFF
--- a/OLE.xs
+++ b/OLE.xs
@@ -86,6 +86,9 @@ my_strrev(char *str)
 }
 
 #   endif /* strrev */
+#   ifndef stricmp
+#     define stricmp strcasecmp
+#   endif /* stricmp */
 #endif
 
 #define PERL_NO_GET_CONTEXT
@@ -475,7 +478,7 @@ IsLocalMachine(pTHX_ SV *host)
 
     /* Check against local computer name (from registry) */
     if (GetComputerNameA(szComputerName, &dwSize)
-        && strcasecmp(pszName, szComputerName) == 0)
+        && stricmp(pszName, szComputerName) == 0)
     {
         return TRUE;
     }

--- a/OLE.xs
+++ b/OLE.xs
@@ -475,7 +475,7 @@ IsLocalMachine(pTHX_ SV *host)
 
     /* Check against local computer name (from registry) */
     if (GetComputerNameA(szComputerName, &dwSize)
-        && stricmp(pszName, szComputerName) == 0)
+        && strcasecmp(pszName, szComputerName) == 0)
     {
         return TRUE;
     }


### PR DESCRIPTION
Cygwin have removed stricmp from standard headers

https://cygwin.com/ml/cygwin/2014-10/msg00364.html

Tested with Cygwin and the gcc provided with Strawberry perl
(5.20.2.1)
