### PR TITLE
Fix the issue where Win32::OLE::Const doesn't work with 64bit version…

### DIFF
--- a/OLE.xs
+++ b/OLE.xs
@@ -4937,7 +4937,10 @@ PPCODE:
 		// Retrieve filename of type library
 		char szFile[MAX_PATH+1];
 		LONG cbFile = sizeof(szFile);
-                err = RegQueryValueA(hKeyLangid, "win32", szFile, &cbFile);
+		err = RegQueryValueA(hKeyLangid, "win64", szFile, &cbFile);
+		if (err != ERROR_SUCCESS) {
+		    err = RegQueryValueA(hKeyLangid, "win32", szFile, &cbFile);
+		}
 		if (err == ERROR_SUCCESS && cbFile > 1) {
                     ENTER;
                     SAVETMPS;


### PR DESCRIPTION
… of MS Office applications

To fix the issue, _TypeLibs function now search "win64" key.

Please refer to
- https://stackoverflow.com/questions/25509960/how-to-make-win32ole-work-on-64bit-ms-office-installation
