### PR TITLE
Fix fatal -Werror=format-security errors ( https://github.com/jandubois/win32-ole/issues/10 )

### DIFF
--- a/OLE.xs
+++ b/OLE.xs
@@ -475,7 +475,7 @@ IsLocalMachine(pTHX_ SV *host)
 
     /* Check against local computer name (from registry) */
     if (GetComputerNameA(szComputerName, &dwSize)
-        && stricmp(pszName, szComputerName) == 0)
+        && strcasecmp(pszName, szComputerName) == 0)
     {
         return TRUE;
     }
@@ -917,12 +917,12 @@ ReportOleError(pTHX_ HV *stash, HRESULT hr, EXCEPINFO *pExcep=NULL,
 	if (warnlvl < 3) {
 	    cv = perl_get_cv("Carp::carp", FALSE);
 	    if (!cv)
-		warn(SvPVX(sv));
+		warn("%s", SvPVX(sv));
 	}
 	else {
 	    cv = perl_get_cv("Carp::croak", FALSE);
 	    if (!cv)
-		croak(SvPVX(sv));
+		croak("%s", SvPVX(sv));
 	}
     }
 


### PR DESCRIPTION
Fix issue 10 ( https://github.com/jandubois/win32-ole/issues/10 )

OLE.xs had warn(SvPVX(sv)) and croak(SvPVX(sv)) with no format string specified, which
resulted in errors with  -Werror=format-security
  format not a string literal and no format arguments
Pass "%s" format string through to get compile work

oh, also apply one of the 'strcasecmp' errorsfor cygwin too

Not sure why the .xs file from CPAN has other (unapplied) changes, not addressed

Also unresolved, an unrelated make test warning

t/2_variant.t ... Failed 1/38 subtests

Win32::OLE->Option(LCID => $lcidEnglish);
$v = Variant(VT_DATE, "1 may 1999 17:00");
my $str = $v->Date(DATE_LONGDATE);
print "# LONGDATE is '$str'\n";
print "not " unless $str eq 'Saturday, May 01, 1999';
printf "ok %d\n", ++$Test;

Looks like we are expcting a leading 0 in the DATE_LONGDATE format
  # LONGDATE is 'Saturday, May 1, 1999'
main::(q.t:39): print "not " unless $str eq 'Saturday, May 01, 1999';