### PR TITLE
t/3_ole.t: Stop checking decimal currency value because it depends on OS locale

### DIFF
--- a/t/3_ole.t
+++ b/t/3_ole.t
@@ -262,10 +262,11 @@ print "not " unless $Cell->Value eq 'x';
 printf "ok %d\n", ++$Test;
 
 # 19. Try to roundtrip a VT_CY value and see if it stays a Variant
-$Cell->{Value} = Variant(VT_CY, 1.25);
+$Cell->{Value} = Variant(VT_CY, 125);
 $Value = $Cell->{Value};
 printf "# Value is %s, ref=%s, type=%d\n", $Value, ref $Value, $Value->Type;
-print "not " unless ref($Value) eq "Excel::Variant" &&
+print "not " unless $Cell->Value == 125 &&
+                    ref($Value) eq "Excel::Variant" &&
                     $Value->Type == VT_CY;
 printf "ok %d\n", ++$Test;
 

--- a/t/3_ole.t
+++ b/t/3_ole.t
@@ -265,8 +265,7 @@ printf "ok %d\n", ++$Test;
 $Cell->{Value} = Variant(VT_CY, 1.25);
 $Value = $Cell->{Value};
 printf "# Value is %s, ref=%s, type=%d\n", $Value, ref $Value, $Value->Type;
-print "not " unless $Cell->Value == 1.25 &&
-                    ref($Value) eq "Excel::Variant" &&
+print "not " unless ref($Value) eq "Excel::Variant" &&
                     $Value->Type == VT_CY;
 printf "ok %d\n", ++$Test;
 


### PR DESCRIPTION
This is for the test failure of t/3_ole.t on Japanese locale:
http://www.cpantesters.org/cpan/report/30331b72-6de5-1014-8029-8c7db0dd06cd

https://github.com/jandubois/win32-ole/blob/689818b4e1cbd29e1f456cd6b3abfde6a410fa32/t/3_ole.t#L264-L271

On my Windows environment (Japanese locale), it fails as below:
```
# Value is 1, ref=Excel::Variant, type=6
not ok 19
```

The value 1.25 is converted to 1 because "No. of digits after decimal" setting is set to 0 for Japanese currency (yen) by default. For U.S. currency (dollar),  "No. of digits after decimal" is set to 2. When I change the setting from 0 to 2, the test passes.

For reference, to check "No. of digits after decimal" Windows OS setting, go to Control Panel, then click Region and Language, then click Additional Settings. Next, select Currency tab.

If the purpose of this test is to "see if it stays a Variant", there is no need to see if the value is 1.25 or 1.